### PR TITLE
[Contracts] Add escrow expiration extension functionality

### DIFF
--- a/contracts/src/events.rs
+++ b/contracts/src/events.rs
@@ -15,6 +15,7 @@ pub enum EventData {
     EscrowApproved(u64),
     EscrowReleased(u64, i128),
     EscrowRefunded(u64, i128),
+    EscrowExtended(u64, u64),
     InvoiceCreated(u64, u64, Address, Address, AssetRef, i128),
     InvoicePaid(u64, u64, i128),
     InvoiceUpdated(u64, i128, i128),

--- a/contracts/src/payment_escrow.rs
+++ b/contracts/src/payment_escrow.rs
@@ -2229,6 +2229,52 @@ impl PaymentEscrowContract {
 
         Ok(())
     }
+    pub fn extend_escrow(
+        env: Env,
+        escrow_id: u64,
+        caller: Address,
+        new_expiration: u64,
+    ) -> Result<(), Error> {
+        caller.require_auth();
+
+        let mut escrow: Escrow = env
+            .storage()
+            .instance()
+            .get(&DataKey::Escrow(escrow_id))
+            .ok_or(Error::EscrowNotFound)?;
+
+        if caller != escrow.sender && caller != escrow.recipient {
+            return Err(Error::Unauthorized);
+        }
+
+        let current_time = env.ledger().timestamp();
+        if current_time > escrow.release_conditions.expiration_timestamp {
+            return Err(Error::Expired);
+        }
+
+        if new_expiration <= current_time {
+            return Err(Error::InvalidAmount);
+        }
+
+        escrow.release_conditions.expiration_timestamp = new_expiration;
+        env.storage()
+            .instance()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+
+        events::emit(
+            &env,
+            symbol_short!("escrow"),
+            symbol_short!("extended"),
+            escrow_id,
+            &caller,
+            new_expiration as i128,
+            symbol_short!("active"),
+            EventData::EscrowExtended(escrow_id, new_expiration),
+        );
+
+        Ok(())
+    }
+
     pub fn release_escrow(
         env: Env,
         escrow_id: u64,

--- a/contracts/tests/timelock_test.rs
+++ b/contracts/tests/timelock_test.rs
@@ -48,6 +48,217 @@ fn setup_test<'a>(
     (client, admin, sender, recipient, token, asset)
 }
 
+// ── extend_escrow tests ───────────────────────────────────────────────────
+
+#[test]
+fn test_extend_escrow_by_sender() {
+    let env = Env::default();
+    let (client, _admin, sender, _recipient, (_, token_admin), asset) = setup_test(&env);
+
+    let amount = 1000;
+    let expiration = 2000u64;
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+    token_admin.mint(&sender, &amount);
+
+    let escrow_id = client.create_escrow(
+        &sender,
+        &_recipient,
+        &amount,
+        &asset,
+        &expiration,
+        &String::from_str(&env, "Test"),
+    );
+
+    // Sender extends expiration
+    let new_expiration = 3000u64;
+    let result = client.try_extend_escrow(&escrow_id, &sender, &new_expiration);
+    assert!(result.is_ok());
+
+    let escrow = client.get_escrow(&escrow_id).unwrap();
+    assert_eq!(escrow.release_conditions.expiration_timestamp, new_expiration);
+}
+
+#[test]
+fn test_extend_escrow_by_recipient() {
+    let env = Env::default();
+    let (client, _admin, sender, recipient, (_, token_admin), asset) = setup_test(&env);
+
+    let amount = 1000;
+    let expiration = 2000u64;
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+    token_admin.mint(&sender, &amount);
+
+    let escrow_id = client.create_escrow(
+        &sender,
+        &recipient,
+        &amount,
+        &asset,
+        &expiration,
+        &String::from_str(&env, "Test"),
+    );
+
+    // Recipient extends expiration
+    let new_expiration = 3000u64;
+    let result = client.try_extend_escrow(&escrow_id, &recipient, &new_expiration);
+    assert!(result.is_ok());
+
+    let escrow = client.get_escrow(&escrow_id).unwrap();
+    assert_eq!(escrow.release_conditions.expiration_timestamp, new_expiration);
+}
+
+#[test]
+fn test_extend_escrow_unauthorized() {
+    let env = Env::default();
+    let (client, _admin, sender, recipient, (_, token_admin), asset) = setup_test(&env);
+
+    let amount = 1000;
+    let expiration = 2000u64;
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+    token_admin.mint(&sender, &amount);
+
+    let escrow_id = client.create_escrow(
+        &sender,
+        &recipient,
+        &amount,
+        &asset,
+        &expiration,
+        &String::from_str(&env, "Test"),
+    );
+
+    let stranger = Address::generate(&env);
+    let result = client.try_extend_escrow(&escrow_id, &stranger, &3000u64);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_extend_escrow_after_expiration_fails() {
+    let env = Env::default();
+    let (client, _admin, sender, recipient, (_, token_admin), asset) = setup_test(&env);
+
+    let amount = 1000;
+    let expiration = 2000u64;
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+    token_admin.mint(&sender, &amount);
+
+    let escrow_id = client.create_escrow(
+        &sender,
+        &recipient,
+        &amount,
+        &asset,
+        &expiration,
+        &String::from_str(&env, "Test"),
+    );
+
+    // Advance past expiration
+    env.ledger().with_mut(|li| li.timestamp = expiration + 1);
+
+    let result = client.try_extend_escrow(&escrow_id, &sender, &(expiration + 5000));
+    assert_eq!(result, Err(Ok(Error::Expired)));
+}
+
+#[test]
+fn test_extend_escrow_new_expiration_in_past_fails() {
+    let env = Env::default();
+    let (client, _admin, sender, recipient, (_, token_admin), asset) = setup_test(&env);
+
+    let amount = 1000;
+    let expiration = 2000u64;
+
+    env.ledger().with_mut(|li| li.timestamp = 1500);
+    token_admin.mint(&sender, &amount);
+
+    let escrow_id = client.create_escrow(
+        &sender,
+        &recipient,
+        &amount,
+        &asset,
+        &expiration,
+        &String::from_str(&env, "Test"),
+    );
+
+    // New expiration is in the past relative to current time (1500)
+    let result = client.try_extend_escrow(&escrow_id, &sender, &1000u64);
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+}
+
+#[test]
+fn test_extend_escrow_new_expiration_at_current_time_fails() {
+    let env = Env::default();
+    let (client, _admin, sender, recipient, (_, token_admin), asset) = setup_test(&env);
+
+    let amount = 1000;
+    let expiration = 2000u64;
+
+    env.ledger().with_mut(|li| li.timestamp = 1500);
+    token_admin.mint(&sender, &amount);
+
+    let escrow_id = client.create_escrow(
+        &sender,
+        &recipient,
+        &amount,
+        &asset,
+        &expiration,
+        &String::from_str(&env, "Test"),
+    );
+
+    // new_expiration == current_time should be rejected (must be strictly in future)
+    let result = client.try_extend_escrow(&escrow_id, &sender, &1500u64);
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+}
+
+#[test]
+fn test_extend_escrow_allows_release_in_extended_window() {
+    let env = Env::default();
+    let (client, _admin, sender, recipient, (token, token_admin), asset) = setup_test(&env);
+
+    let amount = 1000;
+    let expiration = 2000u64;
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+    token_admin.mint(&sender, &amount);
+
+    let escrow_id = client.create_escrow(
+        &sender,
+        &recipient,
+        &amount,
+        &asset,
+        &expiration,
+        &String::from_str(&env, "Test"),
+    );
+
+    client.deposit(&escrow_id, &sender, &amount, &token.address);
+
+    // Extend before original expiration
+    env.ledger().with_mut(|li| li.timestamp = 1800);
+    client.extend_escrow(&escrow_id, &sender, &3000u64);
+
+    // Advance past original expiration but within new window
+    env.ledger().with_mut(|li| li.timestamp = 2500);
+
+    let result = client.try_release_escrow(&escrow_id, &recipient, &token.address);
+    assert!(result.is_ok());
+
+    let escrow = client.get_escrow(&escrow_id).unwrap();
+    assert_eq!(escrow.status, EscrowStatus::Released);
+}
+
+#[test]
+fn test_extend_escrow_not_found() {
+    let env = Env::default();
+    let (client, _admin, sender, _recipient, _token, _asset) = setup_test(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let result = client.try_extend_escrow(&999u64, &sender, &5000u64);
+    assert_eq!(result, Err(Ok(Error::EscrowNotFound)));
+}
+
+// ── expiration boundary tests ─────────────────────────────────────────────
+
 // Test expiration at exact timestamp boundary
 #[test]
 fn test_expiration_at_exact_boundary() {


### PR DESCRIPTION
## Summary

- Adds `extend_escrow(env, escrow_id, caller, new_expiration)` to `payment_escrow.rs`
- Only the escrow sender or recipient can call it; unauthorized callers get `Error::Unauthorized`
- Cannot extend an already-expired escrow (`Error::Expired`)
- New expiration must be strictly in the future (`Error::InvalidAmount`)
- Emits `EscrowExtended(escrow_id, new_expiration)` event on success (new variant added to `EventData`)
- Eight tests added to `timelock_test.rs` covering all acceptance criteria

## Test plan

- [ ] `test_extend_escrow_by_sender` — sender can extend before expiry
- [ ] `test_extend_escrow_by_recipient` — recipient can extend before expiry
- [ ] `test_extend_escrow_unauthorized` — third party is rejected
- [ ] `test_extend_escrow_after_expiration_fails` — cannot extend expired escrow
- [ ] `test_extend_escrow_new_expiration_in_past_fails` — past timestamp rejected
- [ ] `test_extend_escrow_new_expiration_at_current_time_fails` — current timestamp rejected
- [ ] `test_extend_escrow_allows_release_in_extended_window` — release succeeds after extension moves window forward
- [ ] `test_extend_escrow_not_found` — missing escrow returns `EscrowNotFound`

Closes #121
Closes #122
Closes #123
Closes #124