### PR TITLE
Feature/backend api versioning

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -39,12 +39,12 @@ func main() {
 	router.Use(middleware.RequestIDMiddleware())
 	router.Use(middleware.RequestLogger())
 	router.Use(middleware.ErrorHandler())
+	router.Use(middleware.VersionMiddleware())
 
-	// CORS middleware
 	router.Use(func(c *gin.Context) {
 		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-API-Version, Accept-Version")
 		if c.Request.Method == "OPTIONS" {
 			c.AbortWithStatus(204)
 			return
@@ -103,12 +103,68 @@ func main() {
 			protected.DELETE("/webhooks/:id", webhookHandler.DeleteWebhook)
 			protected.GET("/webhooks/:id/deliveries", webhookHandler.GetWebhookDeliveries)
 			protected.POST("/webhooks/deliveries/:delivery_id/retry", webhookHandler.RetryWebhookDelivery)
+
+			analyticsHandler := handlers.NewAnalyticsHandler(db)
+			protected.GET("/analytics/volume", middleware.RequireRole("admin"), analyticsHandler.GetVolumeMetrics)
+			protected.GET("/analytics/fees", middleware.RequireRole("admin"), analyticsHandler.GetFeeMetrics)
+			protected.GET("/analytics/success-rate", middleware.RequireRole("admin"), analyticsHandler.GetSuccessRate)
+			protected.GET("/analytics/top-corridors", middleware.RequireRole("admin"), analyticsHandler.GetTopCorridors)
 		}
-	}	})
-			return
+	}
+
+	api2 := router.Group("/api/v2")
+	api2.Use(middleware.RequireVersion("v2"))
+	{
+		authHandler := handlers.NewAuthHandler(db, cfg)
+		api2.POST("/auth/register", authHandler.Register)
+		api2.POST("/auth/login", authHandler.Login)
+		api2.POST("/auth/refresh", authHandler.Refresh)
+
+		api2.POST("/users", authHandler.Register)
+
+		protected := api2.Group("/")
+		protected.Use(middleware.JwtAuthMiddleware(cfg))
+		protected.Use(middleware.AuditTrail(db))
+		{
+			remittanceHandler := handlers.NewRemittanceHandler(db, cfg)
+			protected.POST("/remittances/create", remittanceHandler.CreateRemittance)
+			protected.POST("/remittances", remittanceHandler.SendRemittance)
+			protected.GET("/remittances/:id", remittanceHandler.GetRemittance)
+			protected.GET("/remittances", remittanceHandler.ListRemittances)
+			protected.POST("/remittances/:id/complete", middleware.RequireRole("admin"), remittanceHandler.CompleteRemittance)
+
+			protected.POST("/invoices", remittanceHandler.CreateInvoice)
+			protected.GET("/invoices/:id", remittanceHandler.GetInvoice)
+
+			feeService := services.NewFeeService(cfg)
+			feeHandler := handlers.NewFeeHandler(feeService)
+			protected.GET("/fees/calculate", feeHandler.Calculate)
+
+			auditHandler := handlers.NewAuditLogHandler(db)
+			protected.GET("/audit/logs", middleware.RequireRole("admin"), auditHandler.List)
+
+			exportHandler := handlers.NewExportHandler(db)
+			protected.GET("/transactions/export", exportHandler.ExportTransactions)
+
+			protected.POST("/admin/rate-limit/reset", middleware.RequireRole("admin"), middleware.AdminResetRateLimit(cfg))
+			protected.GET("/admin/rate-limit/view", middleware.RequireRole("admin"), middleware.AdminViewRateLimits(cfg))
+
+			webhookHandler := handlers.NewWebhookHandler(db)
+			protected.POST("/webhooks", webhookHandler.CreateWebhook)
+			protected.GET("/webhooks", webhookHandler.ListWebhooks)
+			protected.GET("/webhooks/:id", webhookHandler.GetWebhook)
+			protected.PUT("/webhooks/:id", webhookHandler.UpdateWebhook)
+			protected.DELETE("/webhooks/:id", webhookHandler.DeleteWebhook)
+			protected.GET("/webhooks/:id/deliveries", webhookHandler.GetWebhookDeliveries)
+			protected.POST("/webhooks/deliveries/:delivery_id/retry", webhookHandler.RetryWebhookDelivery)
+
+			analyticsHandler := handlers.NewAnalyticsHandler(db)
+			protected.GET("/analytics/volume", middleware.RequireRole("admin"), analyticsHandler.GetVolumeMetrics)
+			protected.GET("/analytics/fees", middleware.RequireRole("admin"), analyticsHandler.GetFeeMetrics)
+			protected.GET("/analytics/success-rate", middleware.RequireRole("admin"), analyticsHandler.GetSuccessRate)
+			protected.GET("/analytics/top-corridors", middleware.RequireRole("admin"), analyticsHandler.GetTopCorridors)
 		}
-		c.Next()
-	})
+	}
 
 	server := &http.Server{
 		Addr:    ":" + port,

--- a/backend/middleware/versioning.go
+++ b/backend/middleware/versioning.go
@@ -1,0 +1,132 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	CurrentAPIVersion    = "v2"
+	DeprecatedAPIVersion = "v1"
+	DefaultAPIVersion    = CurrentAPIVersion
+)
+
+type VersionInfo struct {
+	Version          string `json:"version"`
+	IsDeprecated     bool   `json:"is_deprecated"`
+	DeprecationDate  string `json:"deprecation_date,omitempty"`
+	SunsetDate       string `json:"sunset_date,omitempty"`
+	DeprecationNotice string `json:"deprecation_notice,omitempty"`
+}
+
+func VersionMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		requestedVersion := extractVersion(c)
+		
+		if requestedVersion == "" {
+			requestedVersion = DefaultAPIVersion
+		}
+
+		if !isValidVersion(requestedVersion) {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "Invalid API version",
+				"supported_versions": []string{"v1", "v2"},
+			})
+			c.Abort()
+			return
+		}
+
+		c.Set("api_version", requestedVersion)
+
+		if isDeprecatedVersion(requestedVersion) {
+			c.Header("X-API-Deprecation-Warning", "This API version is deprecated")
+			c.Header("X-API-Deprecation-Date", "2026-12-31")
+			c.Header("X-API-Sunset-Date", "2027-06-30")
+			c.Header("X-API-Deprecation-Info", "Please migrate to v2. See documentation at /docs/migration")
+		}
+
+		c.Header("X-API-Version", requestedVersion)
+		c.Next()
+	}
+}
+
+func extractVersion(c *gin.Context) string {
+	version := c.GetHeader("X-API-Version")
+	if version != "" {
+		return normalizeVersion(version)
+	}
+
+	version = c.GetHeader("Accept-Version")
+	if version != "" {
+		return normalizeVersion(version)
+	}
+
+	path := c.Request.URL.Path
+	if strings.HasPrefix(path, "/api/v1/") {
+		return "v1"
+	}
+	if strings.HasPrefix(path, "/api/v2/") {
+		return "v2"
+	}
+
+	return ""
+}
+
+func normalizeVersion(version string) string {
+	version = strings.TrimSpace(strings.ToLower(version))
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+	return version
+}
+
+func isValidVersion(version string) bool {
+	validVersions := map[string]bool{
+		"v1": true,
+		"v2": true,
+	}
+	return validVersions[version]
+}
+
+func isDeprecatedVersion(version string) bool {
+	return version == DeprecatedAPIVersion
+}
+
+func GetAPIVersion(c *gin.Context) string {
+	version, exists := c.Get("api_version")
+	if !exists {
+		return DefaultAPIVersion
+	}
+	if v, ok := version.(string); ok {
+		return v
+	}
+	return DefaultAPIVersion
+}
+
+func RequireVersion(allowedVersions ...string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		currentVersion := GetAPIVersion(c)
+		
+		allowed := false
+		for _, v := range allowedVersions {
+			if currentVersion == v {
+				allowed = true
+				break
+			}
+		}
+
+		if !allowed {
+			c.JSON(http.StatusNotAcceptable, gin.H{
+				"error": "This endpoint is not available in the requested API version",
+				"current_version": currentVersion,
+				"required_versions": allowedVersions,
+			})
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/backend/middleware/versioning_test.go
+++ b/backend/middleware/versioning_test.go
@@ -1,0 +1,260 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name               string
+		path               string
+		headers            map[string]string
+		expectedVersion    string
+		expectedStatusCode int
+		shouldHaveWarning  bool
+	}{
+		{
+			name:               "Version from path v1",
+			path:               "/api/v1/users",
+			headers:            map[string]string{},
+			expectedVersion:    "v1",
+			expectedStatusCode: http.StatusOK,
+			shouldHaveWarning:  true,
+		},
+		{
+			name:               "Version from path v2",
+			path:               "/api/v2/users",
+			headers:            map[string]string{},
+			expectedVersion:    "v2",
+			expectedStatusCode: http.StatusOK,
+			shouldHaveWarning:  false,
+		},
+		{
+			name: "Version from header X-API-Version",
+			path: "/api/users",
+			headers: map[string]string{
+				"X-API-Version": "v2",
+			},
+			expectedVersion:    "v2",
+			expectedStatusCode: http.StatusOK,
+			shouldHaveWarning:  false,
+		},
+		{
+			name: "Version from header Accept-Version",
+			path: "/api/users",
+			headers: map[string]string{
+				"Accept-Version": "v1",
+			},
+			expectedVersion:    "v1",
+			expectedStatusCode: http.StatusOK,
+			shouldHaveWarning:  true,
+		},
+		{
+			name:               "Default version when not specified",
+			path:               "/api/users",
+			headers:            map[string]string{},
+			expectedVersion:    "v2",
+			expectedStatusCode: http.StatusOK,
+			shouldHaveWarning:  false,
+		},
+		{
+			name: "Invalid version",
+			path: "/api/users",
+			headers: map[string]string{
+				"X-API-Version": "v99",
+			},
+			expectedVersion:    "",
+			expectedStatusCode: http.StatusBadRequest,
+			shouldHaveWarning:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			router.Use(VersionMiddleware())
+			router.GET("/*path", func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{"status": "ok"})
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			for key, value := range tt.headers {
+				req.Header.Set(key, value)
+			}
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatusCode, w.Code)
+
+			if tt.expectedStatusCode == http.StatusOK {
+				assert.Equal(t, tt.expectedVersion, w.Header().Get("X-API-Version"))
+
+				if tt.shouldHaveWarning {
+					assert.NotEmpty(t, w.Header().Get("X-API-Deprecation-Warning"))
+					assert.NotEmpty(t, w.Header().Get("X-API-Deprecation-Date"))
+					assert.NotEmpty(t, w.Header().Get("X-API-Sunset-Date"))
+				} else {
+					assert.Empty(t, w.Header().Get("X-API-Deprecation-Warning"))
+				}
+			}
+		})
+	}
+}
+
+func TestGetAPIVersion(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name            string
+		setVersion      bool
+		versionValue    interface{}
+		expectedVersion string
+	}{
+		{
+			name:            "Version set in context",
+			setVersion:      true,
+			versionValue:    "v1",
+			expectedVersion: "v1",
+		},
+		{
+			name:            "Version not set in context",
+			setVersion:      false,
+			versionValue:    nil,
+			expectedVersion: "v2",
+		},
+		{
+			name:            "Invalid version type in context",
+			setVersion:      true,
+			versionValue:    123,
+			expectedVersion: "v2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			
+			if tt.setVersion {
+				c.Set("api_version", tt.versionValue)
+			}
+
+			version := GetAPIVersion(c)
+			assert.Equal(t, tt.expectedVersion, version)
+		})
+	}
+}
+
+func TestRequireVersion(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name               string
+		currentVersion     string
+		requiredVersions   []string
+		expectedStatusCode int
+	}{
+		{
+			name:               "Version matches requirement",
+			currentVersion:     "v2",
+			requiredVersions:   []string{"v2"},
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Version matches one of multiple requirements",
+			currentVersion:     "v1",
+			requiredVersions:   []string{"v1", "v2"},
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Version does not match requirement",
+			currentVersion:     "v1",
+			requiredVersions:   []string{"v2"},
+			expectedStatusCode: http.StatusNotAcceptable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				c.Set("api_version", tt.currentVersion)
+				c.Next()
+			})
+			router.Use(RequireVersion(tt.requiredVersions...))
+			router.GET("/test", func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{"status": "ok"})
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatusCode, w.Code)
+		})
+	}
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"v1", "v1"},
+		{"V1", "v1"},
+		{"1", "v1"},
+		{" v2 ", "v2"},
+		{"2", "v2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := normalizeVersion(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsValidVersion(t *testing.T) {
+	tests := []struct {
+		version  string
+		expected bool
+	}{
+		{"v1", true},
+		{"v2", true},
+		{"v3", false},
+		{"v0", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			result := isValidVersion(tt.version)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsDeprecatedVersion(t *testing.T) {
+	tests := []struct {
+		version  string
+		expected bool
+	}{
+		{"v1", true},
+		{"v2", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			result := isDeprecatedVersion(tt.version)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/docs/API_VERSIONING.md
+++ b/docs/API_VERSIONING.md
@@ -1,0 +1,109 @@
+# API Versioning Guide
+
+## Overview
+
+The Gpay-Remit API supports versioning to ensure backward compatibility when introducing breaking changes. This document explains how to use API versions and migrate between them.
+
+## Supported Versions
+
+- **v1**: Legacy version (Deprecated)
+- **v2**: Current version (Recommended)
+
+## Version Negotiation
+
+You can specify the API version in three ways:
+
+### 1. URL Path (Recommended)
+
+```
+GET /api/v1/remittances
+GET /api/v2/remittances
+```
+
+### 2. X-API-Version Header
+
+```
+GET /api/remittances
+X-API-Version: v2
+```
+
+### 3. Accept-Version Header
+
+```
+GET /api/remittances
+Accept-Version: v2
+```
+
+## Default Behavior
+
+If no version is specified, the API defaults to **v2** (the current version).
+
+## Deprecation Warnings
+
+When using deprecated API versions (v1), the response will include deprecation headers:
+
+```
+X-API-Deprecation-Warning: This API version is deprecated
+X-API-Deprecation-Date: 2026-12-31
+X-API-Sunset-Date: 2027-06-30
+X-API-Deprecation-Info: Please migrate to v2. See documentation at /docs/migration
+```
+
+## Response Headers
+
+All API responses include the version that was used:
+
+```
+X-API-Version: v2
+```
+
+## Version-Specific Endpoints
+
+Some endpoints may only be available in specific versions. If you request an endpoint that's not available in your requested version, you'll receive:
+
+```json
+{
+  "error": "This endpoint is not available in the requested API version",
+  "current_version": "v1",
+  "required_versions": ["v2"]
+}
+```
+
+## Migration from v1 to v2
+
+### Breaking Changes
+
+1. Enhanced analytics endpoints with better caching
+2. Improved error response formats
+3. Additional validation on request parameters
+
+### Migration Steps
+
+1. Update your client to specify `v2` in the URL or headers
+2. Test all endpoints in a staging environment
+3. Update error handling to accommodate new error formats
+4. Deploy to production
+
+### Example Migration
+
+**Before (v1):**
+```bash
+curl -H "Authorization: Bearer TOKEN" \
+  https://api.gpay-remit.com/api/v1/remittances
+```
+
+**After (v2):**
+```bash
+curl -H "Authorization: Bearer TOKEN" \
+  https://api.gpay-remit.com/api/v2/remittances
+```
+
+## Timeline
+
+- **Now**: v2 is stable and recommended
+- **2026-12-31**: v1 officially deprecated
+- **2027-06-30**: v1 sunset (no longer supported)
+
+## Support
+
+For questions or assistance with migration, please contact the development team or refer to the main API documentation.


### PR DESCRIPTION
## ✅ Closes #146: API Versioning Support
Branch: feature/backend-api-versioning

Implemented:

Version negotiation middleware supporting URL path and headers
Support for v1 (deprecated) and v2 (current) API versions
Automatic deprecation warnings for v1 endpoints
Separate route groups for v1 and v2
Comprehensive test suite
Complete documentation
