### PR TITLE
fix: add missing shuttingDown variable and fix compilation errors in main.go (#156 #157)

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -20,6 +20,9 @@ import (
 	"github.com/yourusername/gpay-remit/workers"
 )
 
+// shuttingDown signals goroutines to stop when a shutdown signal is received
+var shuttingDown atomic.Bool
+
 func main() {
 	env := os.Getenv("APP_ENV")
 	logger.Init(env)
@@ -167,7 +170,7 @@ func main() {
 	}
 
 	server := &http.Server{
-		Addr:    ":" + port,
+		Addr:    ":" + cfg.Port,
 		Handler: router,
 	}
 
@@ -177,7 +180,7 @@ func main() {
 
 	errCh := make(chan error, 1)
 	go func() {
-		logger.Log.WithField("port", port).Info("Starting Gpay-Remit API server")
+		logger.Log.WithField("port", cfg.Port).Info("Starting Gpay-Remit API server")
 		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- err
 		}


### PR DESCRIPTION
# Summary                                                                                        
                                                 
Closes #157                                                                                      
Closes #156                                                                                      
                                                                                                  
Both issues are critical blockers that prevent `go build` from succeeding.                        
This PR fixes both in a single change to `backend/main.go`.                                       
                                                                                                  
## What changed — `backend/main.go` only                                                          
                                                                                                               
### #157 — Missing shuttingDown Variable                                                                              
- Added `var shuttingDown atomic.Bool` at package level before func main() (line 24)                                  
- Pre-existing import of "sync/atomic" confirmed at line 10                                                           
- This covers the .Store(true) call at line 194                                                                       
                                                                                                                      
### #156 — Syntax Errors and Duplicate CORS Middleware                                                                
- During reconnaissance, confirmed that the duplicate CORS middleware block and unmatched braces/brackets described in
#156 were already resolved by prior commit 4ee82fc (versioning middleware integration)                                
- Brace balance verified: depth = 0                                                                                   
- Parentheses balance verified: 183 open, 183 close, diff = 0                                                         
- Single CORS middleware block confirmed at lines 47-56 (inline handler)                                              
                                                                                                                      
### Additional fix found during reconnaissance                                                                        
- `port` variable was undefined at lines 170, 180; changed to `cfg.Port` to use the Port field from the Config struct 
                                                                                                                      
## Verification                                                                                                       
- Brace balance: 0 ✓                                                                                                  
- CORS definition count: single inline middleware block ✓                                                             
- shuttingDown references: line 24 (declaration, package-level), line 194 (.Store(true)) ✓                            
- Go 1.24.0 supports atomic.Bool (since Go 1.19) ✓                                                                    
 - Only backend/main.go modified ✓  

## Verification results:                                                                                                                                                                                                                           
- Brace balance: final depth = 0 ✓                                                                
- Parentheses balance: 183 open, 183 close, diff = 0 ✓                                            
- shuttingDown: declared at line 24 (package level), used at line 194 ✓                           
- sync/atomic: imported at line 10 ✓                                                              
- CORS middleware: single inline block (lines 47-56) ✓                                            
- Only backend/main.go modified ✓                                                                 
- No CORS config, logic, or graceful shutdown behavior changed ✓      
