### PR TITLE
fix: replace NewAuthError with NewUnauthorizedError in webhooks handler

### DIFF
--- a/backend/handlers/webhooks.go
+++ b/backend/handlers/webhooks.go
@@ -48,7 +48,7 @@ func (h *WebhookHandler) CreateWebhook(c *gin.Context) {
 
 	userID, exists := c.Get("userID")
 	if !exists {
-		c.Error(errors.NewAuthError("Unauthorized"))
+		c.Error(errors.NewUnauthorizedError("Unauthorized"))
 		return
 	}
 
@@ -90,7 +90,7 @@ func (h *WebhookHandler) CreateWebhook(c *gin.Context) {
 func (h *WebhookHandler) ListWebhooks(c *gin.Context) {
 	userID, exists := c.Get("userID")
 	if !exists {
-		c.Error(errors.NewAuthError("Unauthorized"))
+		c.Error(errors.NewUnauthorizedError("Unauthorized"))
 		return
 	}
 
@@ -120,7 +120,7 @@ func (h *WebhookHandler) ListWebhooks(c *gin.Context) {
 func (h *WebhookHandler) GetWebhook(c *gin.Context) {
 	userID, exists := c.Get("userID")
 	if !exists {
-		c.Error(errors.NewAuthError("Unauthorized"))
+		c.Error(errors.NewUnauthorizedError("Unauthorized"))
 		return
 	}
 
@@ -152,7 +152,7 @@ func (h *WebhookHandler) GetWebhook(c *gin.Context) {
 func (h *WebhookHandler) UpdateWebhook(c *gin.Context) {
 	userID, exists := c.Get("userID")
 	if !exists {
-		c.Error(errors.NewAuthError("Unauthorized"))
+		c.Error(errors.NewUnauthorizedError("Unauthorized"))
 		return
 	}
 
@@ -208,7 +208,7 @@ func (h *WebhookHandler) UpdateWebhook(c *gin.Context) {
 func (h *WebhookHandler) DeleteWebhook(c *gin.Context) {
 	userID, exists := c.Get("userID")
 	if !exists {
-		c.Error(errors.NewAuthError("Unauthorized"))
+		c.Error(errors.NewUnauthorizedError("Unauthorized"))
 		return
 	}
 
@@ -236,7 +236,7 @@ func (h *WebhookHandler) DeleteWebhook(c *gin.Context) {
 func (h *WebhookHandler) GetWebhookDeliveries(c *gin.Context) {
 	userID, exists := c.Get("userID")
 	if !exists {
-		c.Error(errors.NewAuthError("Unauthorized"))
+		c.Error(errors.NewUnauthorizedError("Unauthorized"))
 		return
 	}
 
@@ -270,7 +270,7 @@ func (h *WebhookHandler) GetWebhookDeliveries(c *gin.Context) {
 func (h *WebhookHandler) RetryWebhookDelivery(c *gin.Context) {
 	userID, exists := c.Get("userID")
 	if !exists {
-		c.Error(errors.NewAuthError("Unauthorized"))
+		c.Error(errors.NewUnauthorizedError("Unauthorized"))
 		return
 	}
 


### PR DESCRIPTION
Done. Here's a summary of what was changed:
Branch renamed from Missing-Error-Type-in-Webhooks-Handler → fix/missing-auth-error-function
backend/handlers/webhooks.go — Replaced all 7 errors.NewAuthError() calls with errors.NewUnauthorizedError(), which already exists and performs the same function (lines 51, 93, 123, 155, 211, 239, 273)
No changes needed to errors.go since NewUnauthorizedError already exists there at line 64


closes #155