### PR TITLE
Fix/missing datakey variants

### DIFF
--- a/backend/handlers/webhooks.go
+++ b/backend/handlers/webhooks.go
@@ -48,7 +48,7 @@ func (h *WebhookHandler) CreateWebhook(c *gin.Context) {
 
 	userID, exists := c.Get("userID")
 	if !exists {
-		c.Error(errors.NewAuthError("Unauthorized"))
+		c.Error(errors.NewUnauthorizedError("Unauthorized"))
 		return
 	}
 
@@ -90,7 +90,7 @@ func (h *WebhookHandler) CreateWebhook(c *gin.Context) {
 func (h *WebhookHandler) ListWebhooks(c *gin.Context) {
 	userID, exists := c.Get("userID")
 	if !exists {
-		c.Error(errors.NewAuthError("Unauthorized"))
+		c.Error(errors.NewUnauthorizedError("Unauthorized"))
 		return
 	}
 
@@ -120,7 +120,7 @@ func (h *WebhookHandler) ListWebhooks(c *gin.Context) {
 func (h *WebhookHandler) GetWebhook(c *gin.Context) {
 	userID, exists := c.Get("userID")
 	if !exists {
-		c.Error(errors.NewAuthError("Unauthorized"))
+		c.Error(errors.NewUnauthorizedError("Unauthorized"))
 		return
 	}
 
@@ -152,7 +152,7 @@ func (h *WebhookHandler) GetWebhook(c *gin.Context) {
 func (h *WebhookHandler) UpdateWebhook(c *gin.Context) {
 	userID, exists := c.Get("userID")
 	if !exists {
-		c.Error(errors.NewAuthError("Unauthorized"))
+		c.Error(errors.NewUnauthorizedError("Unauthorized"))
 		return
 	}
 
@@ -208,7 +208,7 @@ func (h *WebhookHandler) UpdateWebhook(c *gin.Context) {
 func (h *WebhookHandler) DeleteWebhook(c *gin.Context) {
 	userID, exists := c.Get("userID")
 	if !exists {
-		c.Error(errors.NewAuthError("Unauthorized"))
+		c.Error(errors.NewUnauthorizedError("Unauthorized"))
 		return
 	}
 
@@ -236,7 +236,7 @@ func (h *WebhookHandler) DeleteWebhook(c *gin.Context) {
 func (h *WebhookHandler) GetWebhookDeliveries(c *gin.Context) {
 	userID, exists := c.Get("userID")
 	if !exists {
-		c.Error(errors.NewAuthError("Unauthorized"))
+		c.Error(errors.NewUnauthorizedError("Unauthorized"))
 		return
 	}
 
@@ -270,7 +270,7 @@ func (h *WebhookHandler) GetWebhookDeliveries(c *gin.Context) {
 func (h *WebhookHandler) RetryWebhookDelivery(c *gin.Context) {
 	userID, exists := c.Get("userID")
 	if !exists {
-		c.Error(errors.NewAuthError("Unauthorized"))
+		c.Error(errors.NewUnauthorizedError("Unauthorized"))
 		return
 	}
 

--- a/contracts/src/payment_escrow.rs
+++ b/contracts/src/payment_escrow.rs
@@ -493,6 +493,9 @@ pub enum DataKey {
     EscrowComplianceOverride(u64),
     UserJurisdiction(Address),
     EscrowCancellationConfig(u64),
+    NotificationHooks(u64),
+    NotificationHistory(u64),
+    RecurringCounter,
 }
 
 #[contract]


### PR DESCRIPTION
Changes made: Added NotificationHooks(u64), NotificationHistory(u64), and RecurringCounter variants to the DataKey enum in contracts/src/payment_escrow.rs:496-498. The pre-existing compilation error (unclosed delimiter in the contract impl block) is unrelated to this change.


closes #158 