### PR TITLE
Fix/idempotency cleanup scheduler

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -181,6 +181,7 @@ func main() {
 
 	baseCtx, cancelWorkers := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
+	middleware.StartIdempotencyCleanupScheduler(baseCtx, &wg, db, time.Hour)
 	workers.StartMonitor(baseCtx, &wg)
 
 	errCh := make(chan error, 1)

--- a/backend/middleware/error_handler.go
+++ b/backend/middleware/error_handler.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"fmt"
 	"net/http"
 	"runtime/debug"
 
@@ -39,7 +38,7 @@ func ErrorHandler() gin.HandlerFunc {
 		defer func() {
 			if err := recover(); err != nil {
 				stack := debug.Stack()
-				
+
 				// Extract context info for logging
 				requestID := c.GetString("requestID")
 				userID, _ := c.Get("userID")
@@ -56,7 +55,7 @@ func ErrorHandler() gin.HandlerFunc {
 				resp := ErrorResponse{}
 				resp.Error.Code = errors.CodeInternal
 				resp.Error.Message = "An internal server error occurred"
-				
+
 				c.AbortWithStatusJSON(http.StatusInternalServerError, resp)
 			}
 		}()
@@ -71,7 +70,7 @@ func ErrorHandler() gin.HandlerFunc {
 
 			var appErr *errors.AppError
 			var ok bool
-			
+
 			if appErr, ok = err.(*errors.AppError); !ok {
 				// Wrap unknown errors as internal errors
 				appErr = errors.NewInternalError("An unexpected error occurred", err)

--- a/backend/middleware/idempotency.go
+++ b/backend/middleware/idempotency.go
@@ -1,7 +1,7 @@
 package middleware
 
 import (
-	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -19,14 +19,14 @@ import (
 
 // IdempotencyConfig holds configuration for idempotency middleware
 type IdempotencyConfig struct {
-	TTL           time.Duration // Time to live for idempotency keys (default: 24 hours)
+	TTL            time.Duration // Time to live for idempotency keys (default: 24 hours)
 	AllowedMethods []string      // HTTP methods that require idempotency keys
 }
 
 // DefaultIdempotencyConfig returns default configuration
 func DefaultIdempotencyConfig() IdempotencyConfig {
 	return IdempotencyConfig{
-		TTL:           24 * time.Hour,
+		TTL:            24 * time.Hour,
 		AllowedMethods: []string{"POST", "PUT", "PATCH"},
 	}
 }
@@ -272,12 +272,10 @@ func updateIdempotencyRecord(c *gin.Context, key string, db *gorm.DB) {
 
 	// Get response body
 	responseBody := ""
-	if rw, ok := c.Writer.(*gin.ResponseWriter); ok {
-		// Try to capture response from context if stored
-		if val, exists := c.Get("idempotency_response"); exists {
-			if resp, ok := val.(string); ok {
-				responseBody = resp
-			}
+	// Try to capture response from context if stored
+	if val, exists := c.Get("idempotency_response"); exists {
+		if resp, ok := val.(string); ok {
+			responseBody = resp
 		}
 	}
 
@@ -285,9 +283,12 @@ func updateIdempotencyRecord(c *gin.Context, key string, db *gorm.DB) {
 	record.Status = "completed"
 	record.ResponseStatus = statusCode
 	record.ResponseBody = responseBody
-	record.CompletedAt = time.Now()
+	now := time.Now()
+	record.CompletedAt = &now
 
-	db.Save(&record)
+	if err := db.Save(&record).Error; err != nil {
+		return
+	}
 
 	// Update in-memory cache
 	if val, ok := idempotencyCache.Load(key); ok {
@@ -314,17 +315,33 @@ func bytesBufferPool(b []byte) *strings.Reader {
 }
 
 // CleanupExpiredIdempotencyRecords removes expired idempotency records
-func CleanupExpiredIdempotencyRecords(db *gorm.DB) error {
-	return db.Where("expires_at < ?", time.Now()).Delete(&models.IdempotencyRecord{}).Error
+func CleanupExpiredIdempotencyRecords(db *gorm.DB) (int64, error) {
+	result := db.Where("expires_at < ?", time.Now()).Delete(&models.IdempotencyRecord{})
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	return result.RowsAffected, nil
 }
 
 // StartIdempotencyCleanupScheduler starts a background job to clean up expired records
-func StartIdempotencyCleanupScheduler(db *gorm.DB, interval time.Duration) {
+func StartIdempotencyCleanupScheduler(ctx context.Context, wg *sync.WaitGroup, db *gorm.DB, interval time.Duration) {
 	ticker := time.NewTicker(interval)
+	wg.Add(1)
 	go func() {
-		for range ticker.C {
-			if err := CleanupExpiredIdempotencyRecords(db); err != nil {
-				fmt.Printf("Error cleaning up idempotency records: %v\n", err)
+		defer wg.Done()
+		for {
+			select {
+			case <-ticker.C:
+				rowsAffected, err := CleanupExpiredIdempotencyRecords(db)
+				if err != nil {
+					fmt.Printf("Error cleaning up idempotency records: %v\n", err)
+				} else {
+					fmt.Printf("Cleaned up %d expired idempotency records\n", rowsAffected)
+				}
+			case <-ctx.Done():
+				ticker.Stop()
+				fmt.Println("Idempotency cleanup scheduler stopped")
+				return
 			}
 		}
 	}()

--- a/backend/middleware/idempotency_test.go
+++ b/backend/middleware/idempotency_test.go
@@ -1,0 +1,55 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yourusername/gpay-remit/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestStartIdempotencyCleanupSchedulerCleansExpiredRecords(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.IdempotencyRecord{}))
+
+	now := time.Now()
+	expiredRecord := models.IdempotencyRecord{
+		IdempotencyKey: "expired-key",
+		RequestHash:    "expired-hash",
+		RequestMethod:  "POST",
+		RequestPath:    "/payments",
+		Status:         "completed",
+		ExpiresAt:      now.Add(-time.Hour),
+	}
+	activeRecord := models.IdempotencyRecord{
+		IdempotencyKey: "active-key",
+		RequestHash:    "active-hash",
+		RequestMethod:  "POST",
+		RequestPath:    "/payments",
+		Status:         "completed",
+		ExpiresAt:      now.Add(time.Hour),
+	}
+
+	require.NoError(t, db.Create(&expiredRecord).Error)
+	require.NoError(t, db.Create(&activeRecord).Error)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	StartIdempotencyCleanupScheduler(ctx, db, 10*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		var count int64
+		err := db.Model(&models.IdempotencyRecord{}).Count(&count).Error
+		return err == nil && count == 1
+	}, time.Second, 10*time.Millisecond)
+
+	var remaining []models.IdempotencyRecord
+	require.NoError(t, db.Find(&remaining).Error)
+	require.Len(t, remaining, 1)
+	require.Equal(t, "active-key", remaining[0].IdempotencyKey)
+}


### PR DESCRIPTION
close #179 

Description

This PR addresses the issue where expired idempotency records were accumulating in the database by properly invoking and managing the StartIdempotencyCleanupScheduler.

Changes Made:
* Scheduler Activation: Integrated the StartIdempotencyCleanupScheduler call in backend/main.go using a 1-hour interval.
* Graceful Shutdown: Added context.Context and *sync.WaitGroup arguments to the scheduler. It now appropriately stops the ticker and completes the goroutine during the application's shutdown sequence.
* Logging Statistics: The scheduler now logs the exact number of expired idempotency records it clears every tick (Cleaned up <n> expired idempotency records).
* Fix: Resolved an invalid type assertion panic (c.Writer.(*gin.ResponseWriter)) within idempotency.go.

Acceptance Criteria Met

* Call StartIdempotencyCleanupScheduler in main.go
* Set cleanup interval to 1 hour
* Add graceful shutdown for cleanup goroutine
* Log cleanup statistics

Testing

* Verified compilation success using go build main.go.
* Application boot sequence accurately initializes the scheduler alongside background workers.