### PR TITLE
fix(#176): Redis Cache Not Configured

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,16 @@ jobs:
   test-backend:
     name: Test Backend
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v3
 
@@ -36,6 +46,8 @@ jobs:
 
       - name: Run backend tests
         working-directory: ./backend
+        env:
+          REDIS_ADDR: localhost:6379
         run: |
           go mod download
           go test ./...

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -32,3 +32,8 @@ SMTP_PORT=465
 SMTP_USER=your-email@gmail.com
 SMTP_PASSWORD=your-app-password
 SMTP_FROM=noreply@gpay-remit.com
+
+# Redis Configuration
+REDIS_ADDR=localhost:6379
+REDIS_PASSWORD=
+REDIS_DB=0

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -46,6 +46,11 @@ type Config struct {
 	SMTPPassword string
 	SMTPFrom     string
 	EmailEnabled bool
+
+	// Redis configuration
+	RedisAddr     string
+	RedisPassword string
+	RedisDB       int
 }
 
 func LoadConfig() (*Config, error) {
@@ -79,6 +84,10 @@ func LoadConfig() (*Config, error) {
 		SMTPPassword: os.Getenv("SMTP_PASSWORD"),
 		SMTPFrom:     getEnvOrDefault("SMTP_FROM", os.Getenv("SMTP_USER")),
 		EmailEnabled: getEnvOrDefault("EMAIL_ENABLED", "false") == "true",
+
+		RedisAddr:     getEnvOrDefault("REDIS_ADDR", "localhost:6379"),
+		RedisPassword: os.Getenv("REDIS_PASSWORD"),
+		RedisDB:       getEnvAsInt("REDIS_DB", 0),
 	}, nil
 }
 

--- a/backend/handlers/auth_test.go
+++ b/backend/handlers/auth_test.go
@@ -213,16 +213,18 @@ func TestLogin(t *testing.T) {
 	t.Run("Inactive User Returns 403", func(t *testing.T) {
 		handler, r := setupAuthHandler(t)
 
-		// Create inactive user directly in DB
+		// Create user first (IsActive defaults to true via GORM tag), then deactivate.
 		hash, _ := models.HashPassword("Secure@Inactive1")
 		user := models.User{
 			Email:          "inactive@example.com",
 			Name:           "Inactive User",
 			PasswordHash:   hash,
 			StellarAddress: "GDQJUTQYK2MQX2VGDR2FYWLIYAQIEGXTQVTFEMGH6DNHFMHIDENFINIAC",
-			IsActive:       false,
+			IsActive:       true,
 		}
 		handler.DB.Create(&user)
+		// Explicitly set IsActive = false after insert to bypass GORM zero-value handling.
+		handler.DB.Model(&user).Update("is_active", false)
 
 		body, _ := json.Marshal(map[string]string{
 			"email":    "inactive@example.com",

--- a/backend/handlers/export_test.go
+++ b/backend/handlers/export_test.go
@@ -174,6 +174,7 @@ func TestExportTransactionsInvalidFormat(t *testing.T) {
 	handler := NewExportHandler(db)
 	router := gin.New()
 	router.Use(gin.Recovery())
+	router.Use(errorHandlerForTests())
 	router.GET("/api/v1/transactions/export", handler.ExportTransactions)
 
 	w := httptest.NewRecorder()
@@ -190,6 +191,7 @@ func TestExportTransactionsNoData(t *testing.T) {
 	handler := NewExportHandler(db)
 	router := gin.New()
 	router.Use(gin.Recovery())
+	router.Use(errorHandlerForTests())
 	router.GET("/api/v1/transactions/export", handler.ExportTransactions)
 
 	w := httptest.NewRecorder()

--- a/backend/handlers/health.go
+++ b/backend/handlers/health.go
@@ -61,7 +61,9 @@ func (h *HealthHandler) Health(c *gin.Context) {
 
 	overall := "healthy"
 	httpStatus := http.StatusOK
-	if dbStatus.Status != "healthy" || horizonStatus.Status != "healthy" || redisStatus.Status != "healthy" {
+	// "unconfigured" is a known, non-fatal state — Redis is optional.
+	if dbStatus.Status != "healthy" || horizonStatus.Status != "healthy" ||
+		(redisStatus.Status != "healthy" && redisStatus.Status != "unconfigured") {
 		overall = "degraded"
 		httpStatus = http.StatusServiceUnavailable
 	}
@@ -84,7 +86,9 @@ func (h *HealthHandler) Ready(c *gin.Context) {
 	horizonStatus := h.checkHorizon()
 	redisStatus := h.checkRedis()
 
-	if dbStatus.Status != "healthy" || horizonStatus.Status != "healthy" || redisStatus.Status != "healthy" {
+	// "unconfigured" is non-fatal for readiness — allow the pod to serve traffic.
+	if dbStatus.Status != "healthy" || horizonStatus.Status != "healthy" ||
+		(redisStatus.Status != "healthy" && redisStatus.Status != "unconfigured") {
 		c.JSON(http.StatusServiceUnavailable, gin.H{
 			"status":   "not_ready",
 			"database": dbStatus,

--- a/backend/handlers/health_test.go
+++ b/backend/handlers/health_test.go
@@ -16,6 +16,7 @@ func setupHealthRouter(t *testing.T) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	db := setupTestDB()
 	cfg := &config.Config{HorizonURL: "https://horizon-testnet.stellar.org"}
+	// No Redis client — tests run without a real Redis; checkRedis returns "unconfigured".
 	handler := NewHealthHandler(db, cfg)
 
 	router := gin.New()
@@ -87,4 +88,36 @@ func TestHealthResponseFields(t *testing.T) {
 	assert.Equal(t, "gpay-remit-api", resp["service"])
 	assert.NotEmpty(t, resp["timestamp"])
 	assert.NotNil(t, resp["dependencies"])
+}
+
+// TestHealthRedisUnconfigured verifies that a nil RedisClient reports
+// "unconfigured" rather than "unhealthy" and does not panic.
+func TestHealthRedisUnconfigured(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	// NewHealthHandler does not inject a Redis client → RedisClient is nil.
+	handler := NewHealthHandler(nil, &config.Config{HorizonURL: ""})
+
+	status := handler.checkRedis()
+
+	assert.Equal(t, "unconfigured", status.Status)
+	assert.NotEmpty(t, status.Error)
+}
+
+// TestHealthWithRedisNilDoesNotPanic exercises the full /health endpoint
+// when no Redis client is wired in, ensuring the handler degrades gracefully.
+func TestHealthWithRedisNilDoesNotPanic(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := NewHealthHandler(nil, &config.Config{HorizonURL: ""})
+	router := gin.New()
+	router.GET("/health", handler.Health)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/health", nil)
+	assert.NotPanics(t, func() { router.ServeHTTP(w, req) })
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	deps, _ := resp["dependencies"].(map[string]interface{})
+	redis, _ := deps["redis"].(map[string]interface{})
+	assert.Equal(t, "unconfigured", redis["status"])
 }

--- a/backend/handlers/remittances_test.go
+++ b/backend/handlers/remittances_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/yourusername/gpay-remit/config"
 	"github.com/yourusername/gpay-remit/models"
+	"github.com/yourusername/gpay-remit/services"
 	"github.com/stellar/go/txnbuild"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -58,10 +59,12 @@ func TestCreateRemittance(t *testing.T) {
 		ValidateAccountFunc: func(accountID string) error { return nil },
 		BuildEscrowTxFunc:   func(sender, recipient, assetCode, issuer, amount string) (string, error) { return "base64_xdr", nil },
 	}
+	testCfg := &config.Config{}
 	handler := &RemittanceHandler{
 		db:            db,
-		config:        &config.Config{},
+		config:        testCfg,
 		stellarClient: mockStellar,
+		fees:          services.NewFeeService(testCfg),
 	}
 
 	router := gin.Default()
@@ -138,9 +141,11 @@ func TestCreateRemittance(t *testing.T) {
 	})
 
 	t.Run("Stellar Client Failure", func(t *testing.T) {
+		failCfg := &config.Config{}
 		failHandler := &RemittanceHandler{
 			db:     db,
-			config: &config.Config{},
+			config: failCfg,
+			fees:   services.NewFeeService(failCfg),
 			stellarClient: &MockStellarClient{
 				ValidateAccountFunc: func(accountID string) error { return nil },
 				BuildEscrowTxFunc: func(sender, recipient, assetCode, issuer, amount string) (string, error) {

--- a/backend/handlers/test_helpers_test.go
+++ b/backend/handlers/test_helpers_test.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yourusername/gpay-remit/errors"
+)
+
+// errorHandlerForTests is a lightweight Gin middleware that mirrors the
+// production ErrorHandler's behaviour: it converts c.Errors entries into
+// proper JSON responses with the correct HTTP status code.
+// Using this in tests avoids a dependency on the middleware package and
+// keeps the handlers package self-contained.
+func errorHandlerForTests() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+
+		if len(c.Errors) == 0 {
+			return
+		}
+
+		ginErr := c.Errors.Last()
+		if c.Writer.Written() {
+			return
+		}
+
+		var appErr *errors.AppError
+		var ok bool
+		if appErr, ok = ginErr.Err.(*errors.AppError); !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": ginErr.Error()})
+			return
+		}
+
+		c.JSON(appErr.HTTPStatus, gin.H{"error": appErr.Message})
+	}
+}

--- a/backend/handlers/webhooks_test.go
+++ b/backend/handlers/webhooks_test.go
@@ -254,6 +254,7 @@ func TestCreateWebhook_InvalidURL(t *testing.T) {
 		c.Set("userID", uint(1))
 		c.Next()
 	})
+	router.Use(errorHandlerForTests())
 	router.POST("/webhooks", handler.CreateWebhook)
 
 	payload := CreateWebhookRequest{
@@ -280,6 +281,7 @@ func TestGetWebhook_NotFound(t *testing.T) {
 		c.Set("userID", uint(1))
 		c.Next()
 	})
+	router.Use(errorHandlerForTests())
 	router.GET("/webhooks/:id", handler.GetWebhook)
 
 	w := httptest.NewRecorder()

--- a/backend/logger/logger_test.go
+++ b/backend/logger/logger_test.go
@@ -1,5 +1,4 @@
 package logger
-package logger
 
 import (
 	"testing"

--- a/backend/main.go
+++ b/backend/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/yourusername/gpay-remit/logger"
 	"github.com/yourusername/gpay-remit/middleware"
 	"github.com/yourusername/gpay-remit/services"
+	"github.com/yourusername/gpay-remit/utils"
 	"github.com/yourusername/gpay-remit/workers"
 )
 
@@ -37,6 +38,14 @@ func main() {
 		logger.Log.WithField("error", err).Fatal("Failed to connect to database")
 	}
 
+	// Initialize Redis — non-fatal: the app runs without Redis but cache and
+	// some health-check fields will be degraded.
+	if err := utils.InitRedis(cfg.RedisAddr, cfg.RedisPassword, cfg.RedisDB); err != nil {
+		logger.Log.WithField("error", err).Warn("Redis unavailable — continuing without cache")
+	} else {
+		logger.Log.WithField("addr", cfg.RedisAddr).Info("Redis connected")
+	}
+
 	router := gin.New()
 	router.Use(gin.Recovery())
 	router.Use(middleware.RequestIDMiddleware())
@@ -55,7 +64,7 @@ func main() {
 		c.Next()
 	})
 
-	healthHandler := handlers.NewHealthHandler(db, cfg)
+	healthHandler := handlers.NewHealthHandlerWithRedis(db, cfg, utils.RedisClient)
 	router.GET("/health", healthHandler.Health)
 	router.GET("/health/ready", healthHandler.Ready)
 	router.GET("/health/live", healthHandler.Live)

--- a/backend/middleware/error_handler.go
+++ b/backend/middleware/error_handler.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"fmt"
 	"net/http"
 	"runtime/debug"
 

--- a/backend/middleware/idempotency.go
+++ b/backend/middleware/idempotency.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -272,12 +271,10 @@ func updateIdempotencyRecord(c *gin.Context, key string, db *gorm.DB) {
 
 	// Get response body
 	responseBody := ""
-	if rw, ok := c.Writer.(*gin.ResponseWriter); ok {
-		// Try to capture response from context if stored
-		if val, exists := c.Get("idempotency_response"); exists {
-			if resp, ok := val.(string); ok {
-				responseBody = resp
-			}
+	// Try to capture response from context if stored
+	if val, exists := c.Get("idempotency_response"); exists {
+		if resp, ok := val.(string); ok {
+			responseBody = resp
 		}
 	}
 
@@ -285,7 +282,8 @@ func updateIdempotencyRecord(c *gin.Context, key string, db *gorm.DB) {
 	record.Status = "completed"
 	record.ResponseStatus = statusCode
 	record.ResponseBody = responseBody
-	record.CompletedAt = time.Now()
+	completedAt := time.Now()
+	record.CompletedAt = &completedAt
 
 	db.Save(&record)
 

--- a/backend/services/analytics_test.go
+++ b/backend/services/analytics_test.go
@@ -228,7 +228,7 @@ func TestCalculateDateRange(t *testing.T) {
 			period:      "yearly",
 			expectError: false,
 			validateRange: func(t *testing.T, start, end time.Time) {
-				assert.Equal(t, 1, start.Month())
+				assert.Equal(t, 1, int(start.Month()))
 				assert.Equal(t, 1, start.Day())
 				assert.NotEqual(t, start.Year(), end.Year())
 			},

--- a/backend/services/webhook_delivery.go
+++ b/backend/services/webhook_delivery.go
@@ -138,7 +138,7 @@ func (s *WebhookDeliveryService) DeliverWebhook(webhook *models.Webhook, deliver
 		logger.Log.WithField("webhook_id", webhook.ID).
 			WithField("delivery_id", delivery.ID).
 			WithField("attempt", attempt+1).
-			WithError(fmt.Errorf(errMsg)).
+			WithError(fmt.Errorf("%s", errMsg)).
 			Warn("Webhook delivery failed, will retry")
 	}
 

--- a/backend/utils/cache_test.go
+++ b/backend/utils/cache_test.go
@@ -1,0 +1,106 @@
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetRedisClient sets RedisClient to nil before each test so tests are
+// isolated regardless of execution order.
+func resetRedisClient() {
+	RedisClient = nil
+}
+
+// TestGetCachedNilClient verifies that GetCached is a no-op when the Redis
+// client has not been initialised (returns false, nil).
+func TestGetCachedNilClient(t *testing.T) {
+	resetRedisClient()
+
+	var dest map[string]interface{}
+	found, err := GetCached("some-key", &dest)
+
+	assert.NoError(t, err)
+	assert.False(t, found)
+	assert.Nil(t, dest)
+}
+
+// TestSetCachedNilClient verifies that SetCached silently succeeds (no-op)
+// when the Redis client is nil.
+func TestSetCachedNilClient(t *testing.T) {
+	resetRedisClient()
+
+	err := SetCached("some-key", map[string]string{"hello": "world"}, time.Minute)
+
+	assert.NoError(t, err)
+}
+
+// TestDeleteCachedNilClient verifies that DeleteCached silently succeeds
+// (no-op) when the Redis client is nil.
+func TestDeleteCachedNilClient(t *testing.T) {
+	resetRedisClient()
+
+	err := DeleteCached("some-key")
+
+	assert.NoError(t, err)
+}
+
+// TestGetCachedNotFound verifies that GetCached returns (false, nil) for a key
+// that has never been stored (requires a live Redis connection; skipped when
+// REDIS_ADDR is not reachable).
+func TestGetCachedNotFound(t *testing.T) {
+	if RedisClient == nil {
+		t.Skip("skipping: no Redis client available")
+	}
+
+	var dest string
+	found, err := GetCached("nonexistent-key-xyz", &dest)
+
+	require.NoError(t, err)
+	assert.False(t, found)
+}
+
+// TestSetAndGetCached verifies that a value stored with SetCached can be
+// retrieved with GetCached (requires a live Redis connection).
+func TestSetAndGetCached(t *testing.T) {
+	if RedisClient == nil {
+		t.Skip("skipping: no Redis client available")
+	}
+
+	type payload struct {
+		Message string `json:"message"`
+	}
+
+	key := "test-set-get-key"
+	want := payload{Message: "hello-redis"}
+
+	require.NoError(t, SetCached(key, want, 10*time.Second))
+	t.Cleanup(func() { _ = DeleteCached(key) })
+
+	var got payload
+	found, err := GetCached(key, &got)
+
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, want, got)
+}
+
+// TestDeleteCached verifies that after a key is deleted GetCached returns false
+// (requires a live Redis connection).
+func TestDeleteCached(t *testing.T) {
+	if RedisClient == nil {
+		t.Skip("skipping: no Redis client available")
+	}
+
+	key := "test-delete-key"
+	require.NoError(t, SetCached(key, "value", 10*time.Second))
+
+	require.NoError(t, DeleteCached(key))
+
+	var dest string
+	found, err := GetCached(key, &dest)
+	require.NoError(t, err)
+	assert.False(t, found)
+}


### PR DESCRIPTION
## Summary

Closes #176

Redis was imported but never wired into the application. This PR connects Redis end-to-end: config → startup → health checks → CI.

---

## What changed

### Core fix
| File | Change |
|---|---|
| `config/config.go` | Added `RedisAddr`, `RedisPassword`, `RedisDB` fields loaded from env vars |
| `backend/.env.example` | Documented `REDIS_ADDR`, `REDIS_PASSWORD`, `REDIS_DB` |
| `backend/main.go` | Calls `utils.InitRedis` after DB init (non-fatal); passes `RedisClient` to health handler |
| `handlers/health.go` | Treats `unconfigured` Redis as non-fatal so pods stay healthy without Redis |
| `handlers/health_test.go` | Adds `TestHealthRedisUnconfigured` and `TestHealthWithRedisNilDoesNotPanic` |
| `utils/cache_test.go` | Tests nil-client no-op behaviour; live tests skip gracefully |
| `.github/workflows/ci.yml` | Adds `redis:7-alpine` service + `REDIS_ADDR` env to backend test job |

### Pre-existing build/test failures resolved
| File | Fix |
|---|---|
| `middleware/idempotency.go` | Unused `bytes` import; impossible `*gin.ResponseWriter` assertion; `CompletedAt` pointer |
| `middleware/error_handler.go` | Unused `fmt` import |
| `logger/logger_test.go` | Duplicate `package logger` declaration |
| `services/webhook_delivery.go` | Non-constant `fmt.Errorf` format string |
| `services/analytics_test.go` | `time.Month` vs `int` type mismatch |
| `handlers/auth_test.go` | GORM zero-value boolean bypass for `IsActive=false` |
| `handlers/remittances_test.go` | Nil `FeeService` in stub handler |
| `handlers/test_helpers_test.go` | New: `errorHandlerForTests()` middleware helper |
| `handlers/export_test.go` | Missing error handler middleware in test routers |
| `handlers/webhooks_test.go` | Missing error handler middleware in test routers |

---

## Testing

```
ok  github.com/yourusername/gpay-remit
ok  github.com/yourusername/gpay-remit/handlers
ok  github.com/yourusername/gpay-remit/logger
ok  github.com/yourusername/gpay-remit/middleware
ok  github.com/yourusername/gpay-remit/models
ok  github.com/yourusername/gpay-remit/services
ok  github.com/yourusername/gpay-remit/utils
ok  github.com/yourusername/gpay-remit/validators
```

All 8 packages pass locally. CI will run with a live Redis 7 instance.

---

## Behaviour notes

- If `REDIS_ADDR` is not reachable at startup the app **warns and continues** — Redis is optional caching, not a hard dependency.
- The `/health` and `/health/ready` endpoints report Redis as `unconfigured` (not `unhealthy`) when no client is wired, keeping pods healthy.
- When Redis is available, `/health` reports latency and full status.